### PR TITLE
chore: Require English in all issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,6 +17,8 @@ body:
           required: true
         - label: I have restarted Home Assistant
           required: true
+        - label: All information in this issue, including logs and screenshots, is written in English. Issues containing non-English content will be closed without response.
+          required: true
 
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -4,6 +4,14 @@ title: "[Feature]: "
 labels: ["enhancement"]
 assignees: ["Nicxe"]
 body:
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: All information in this issue is written in English. Issues containing non-English content will be closed without response.
+          required: true
+
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Summary

- Adds a mandatory checkbox to bug report and feature request templates requiring all submitted information (including logs and screenshots) to be written in English
- Issues containing non-English content will be closed without response

🤖 Generated with [Claude Code](https://claude.com/claude-code)