### PR TITLE
Fix qualifying card inheriting rank from previous Q-part

### DIFF
--- a/f1-sensor-live-data-card.js
+++ b/f1-sensor-live-data-card.js
@@ -9581,7 +9581,8 @@ class F1QualifyingTimingCard extends LitElement {
       } else if (resolvedQPart === 1) {
         position = pos.q1_position ?? null;
       } else {
-        position = this._parsePosition(pos.current_position);
+        const qPos = pos.q3_position ?? pos.q2_position ?? pos.q1_position;
+        position = qPos != null ? qPos : this._parsePosition(pos.current_position);
       }
 
       // Last lap: from laps dict


### PR DESCRIPTION
During an active qualifying segment (e.g. Q3), drivers who had not yet set a lap time inherited their position from the previous segment via the nullish-coalescing fallback chain. This caused them to appear at their Q2 rank and share a position with drivers who had a valid Q3 lap.

Now each Q-part only uses its own segment position. Drivers without a time in the current segment get position=null and sort to the bottom of the standings, which matches the expected behavior described in #50.

Closes #50