### PR TITLE
Add Cadillac Name

### DIFF
--- a/f1-sensor-live-data-card.js
+++ b/f1-sensor-live-data-card.js
@@ -85,6 +85,7 @@ const TEAM_LOGO_ALIASES = {
   astonmartin: 'Aston Martin',
   audi: 'Audi',
   cadillac: 'Cadillac',
+  'cadillac f1 team': 'Cadillac',
   ferrari: 'Ferrari',
   haas: 'Haas',
   mclaren: 'McLaren',


### PR DESCRIPTION
Missing 'Cadillac F1 Team' from Logo Normalization